### PR TITLE
use Rf_warning rather than Function("warning")

### DIFF
--- a/src/scrmr.cpp
+++ b/src/scrmr.cpp
@@ -81,13 +81,12 @@ List scrm(std::string args, std::string file = "") {
   }
   
   /** Throw a warning if -seed argmuent is used */
-  Function warning("warning");
   if (param.random_seed() != -1) 
-    warning("Ignoring Seed argument. Set a seed in R.");
+    Rf_warning("Ignoring Seed argument. Set a seed in R.");
   
   /** Throw a warning if no summary statistics are used */
   if (model.countSummaryStatistics() == 0)
-    warning("No summary statisics specified. No output will be produced.");
+    Rf_warning("No summary statisics specified. No output will be produced.");
   
   Forest forest = Forest(&model, &rrg);
   List sum_stats = initSumStats(forest);


### PR DESCRIPTION
Use the R C API's mechanism for issuing warnings rather than calling back into R to issue a warning. Note that this is required for the scrm tests to pass in the presence of an important change that we are making to the way R code is evaluated, see: https://github.com/RcppCore/Rcpp/issues/241#issuecomment-72315039